### PR TITLE
Fix directory selection outside of Tauri

### DIFF
--- a/src/components/AgentExecution.tsx
+++ b/src/components/AgentExecution.tsx
@@ -18,7 +18,7 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Popover } from "@/components/ui/popover";
 import { api, type Agent } from "@/lib/api";
-import { cn } from "@/lib/utils";
+import { cn, isTauri } from "@/lib/utils";
 import { open } from "@tauri-apps/plugin-dialog";
 import { listen, type UnlistenFn } from "@tauri-apps/api/event";
 import { StreamMessage } from "./StreamMessage";
@@ -186,13 +186,18 @@ export const AgentExecution: React.FC<AgentExecutionProps> = ({
   }, [messages]);
 
   const handleSelectPath = async () => {
+    if (!isTauri()) {
+      setError("Directory selection is only available in the desktop app.");
+      return;
+    }
+
     try {
       const selected = await open({
         directory: true,
         multiple: false,
         title: "Select Project Directory"
       });
-      
+
       if (selected) {
         setProjectPath(selected as string);
         setError(null); // Clear any previous errors

--- a/src/components/ClaudeCodeSession.tsx
+++ b/src/components/ClaudeCodeSession.tsx
@@ -17,7 +17,7 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Popover } from "@/components/ui/popover";
 import { api, type Session } from "@/lib/api";
-import { cn } from "@/lib/utils";
+import { cn, isTauri } from "@/lib/utils";
 import { open } from "@tauri-apps/plugin-dialog";
 import { listen, type UnlistenFn } from "@tauri-apps/api/event";
 import { StreamMessage } from "./StreamMessage";
@@ -196,13 +196,18 @@ export const ClaudeCodeSession: React.FC<ClaudeCodeSessionProps> = ({
   };
 
   const handleSelectPath = async () => {
+    if (!isTauri()) {
+      setError("Directory selection is only available in the desktop app.");
+      return;
+    }
+
     try {
       const selected = await open({
         directory: true,
         multiple: false,
         title: "Select Project Directory"
       });
-      
+
       if (selected) {
         setProjectPath(selected as string);
         setError(null);

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -14,4 +14,15 @@ import { twMerge } from "tailwind-merge";
  */
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
-} 
+}
+
+/**
+ * Detects if the code is running inside a Tauri environment.
+ *
+ * When the frontend is served standalone (e.g. with `bun run dev`) the
+ * `window.__TAURI__` global is not available and calling Tauri APIs will
+ * result in errors like `Cannot read properties of undefined (reading 'invoke')`.
+ */
+export function isTauri(): boolean {
+  return typeof window !== "undefined" && Boolean((window as any).__TAURI__);
+}


### PR DESCRIPTION
## Summary
- guard dialog usage behind a Tauri check
- add `isTauri` helper

## Testing
- `bun x tsc --noEmit` *(fails: Cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_68592b0c631c83248de17afc04e8aead